### PR TITLE
feat(#54): Standardised paths in app

### DIFF
--- a/workspaces/frontend/web/src/common/route.ts
+++ b/workspaces/frontend/web/src/common/route.ts
@@ -1,0 +1,158 @@
+import { Array, Option, pipe } from "effect";
+
+type Regex_az =
+  | "a"
+  | "b"
+  | "c"
+  | "d"
+  | "e"
+  | "f"
+  | "g"
+  | "h"
+  | "i"
+  | "j"
+  | "k"
+  | "l"
+  | "m"
+  | "n"
+  | "o"
+  | "p"
+  | "q"
+  | "r"
+  | "s"
+  | "t"
+  | "u"
+  | "v"
+  | "w"
+  | "x"
+  | "y"
+  | "z";
+type Regez_AZ =
+  | "A"
+  | "B"
+  | "C"
+  | "D"
+  | "E"
+  | "F"
+  | "G"
+  | "H"
+  | "I"
+  | "J"
+  | "K"
+  | "L"
+  | "M"
+  | "N"
+  | "O"
+  | "P"
+  | "Q"
+  | "R"
+  | "S"
+  | "T"
+  | "U"
+  | "V"
+  | "W"
+  | "X"
+  | "Y"
+  | "Z";
+type Regex_09 = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type Regex_w = Regex_az | Regez_AZ | Regex_09 | "_";
+type ParamChar = Regex_w | "-";
+
+// Emulates regex `+`
+type RegexMatchPlus<
+  CharPattern extends string,
+  T extends string,
+> = T extends `${infer First}${infer Rest}`
+  ? First extends CharPattern
+    ? RegexMatchPlus<CharPattern, Rest> extends never
+      ? First
+      : `${First}${RegexMatchPlus<CharPattern, Rest>}`
+    : never
+  : never;
+
+// Recursive helper for finding path parameters in the absence of wildcards
+type _PathParam<Path extends string> =
+  // split path into individual path segments
+  Path extends `${infer L}/${infer R}`
+    ? _PathParam<L> | _PathParam<R>
+    : // find params after `:`
+      Path extends `:${infer Param}`
+      ? Param extends `${infer Optional}?${string}`
+        ? RegexMatchPlus<ParamChar, Optional>
+        : RegexMatchPlus<ParamChar, Param>
+      : // otherwise, there aren't any params present
+        never;
+
+type PathParam<Path extends string> =
+  // check if path is just a wildcard
+  Path extends "*" | "/*"
+    ? "*"
+    : // look for wildcard at the end of the path
+      Path extends `${infer Rest}/*`
+      ? "*" | _PathParam<Rest>
+      : // look for params in the absence of wildcards
+        _PathParam<Path>;
+
+type Params<Path extends string> = {
+  [key in PathParam<Path>]: string | null;
+};
+
+const stringify = (p: string | null) =>
+  pipe(
+    p,
+    Option.fromNullable,
+    Option.match({
+      onSome: (value) => value,
+      onNone: () => "",
+    }),
+  );
+
+/**
+ * Returns a path with params interpolated.
+ * @throws {Error} If an error was encountered during the
+ * interpolation process
+ */
+export function generatePath<Path extends string>(
+  path: Path,
+  params: Params<Path> = {} as Params<Path>,
+): string {
+  if (path.endsWith("*") && path !== "*" && !path.endsWith("/*")) {
+    throw new Error(
+      "The `*` character must always follow a `/` in the path pattern.",
+    );
+  }
+
+  // ensure `/` is added at the beginning if the path is absolute
+  const prefix = path.startsWith("/") ? "/" : "";
+
+  return pipe(
+    path.split(/\/+/),
+    (segments) =>
+      Array.map(segments, (segment, index) => {
+        const isLastSegment = index === segments.length - 1;
+
+        // Only apply the splat if it's the last segment
+        if (isLastSegment && segment === "*") {
+          const star = "*" as PathParam<Path>;
+          return stringify(params[star]);
+        }
+
+        const keyMatch = segment.match(/^:([\w-]+)(\??)$/);
+        if (keyMatch) {
+          const [, key, optional] = keyMatch;
+          const param = params[key as PathParam<Path>];
+
+          if (optional !== "?" && param == null) {
+            throw new Error(`Missing value for "${key}"`);
+          }
+
+          return stringify(param);
+        }
+
+        // Remove any optional markers from optional static segments
+        return segment.replace(/\?$/g, "");
+      }),
+    Array.filter((segment) => !!segment),
+    (segments) => prefix + segments.join("/"),
+  );
+}

--- a/workspaces/frontend/web/src/components/AssetListItem/AssetListItem.tsx
+++ b/workspaces/frontend/web/src/components/AssetListItem/AssetListItem.tsx
@@ -1,4 +1,6 @@
+import { generatePath } from "../../common/route.js";
 import { formatSum } from "../../common/utils.jsx";
+import { Paths } from "../../enums/Paths.js";
 import type {
   AssetListItemFragment,
   FileFragment,
@@ -45,7 +47,10 @@ export const AssetListItem: Component<{ asset: AssetListItemFragment }> = (
           <p class={"card-text"}>{props.asset.description}</p>
         </Show>
 
-        <A href={`/asset/${props.asset.id}`} class={"btn btn-primary"}>
+        <A
+          href={generatePath(Paths.ViewAsset, { id: props.asset.id })}
+          class={"btn btn-primary"}
+        >
           View
         </A>
       </div>

--- a/workspaces/frontend/web/src/components/MainNav/MainNav.tsx
+++ b/workspaces/frontend/web/src/components/MainNav/MainNav.tsx
@@ -1,3 +1,4 @@
+import { Paths } from "../../enums/Paths.js";
 import { A } from "@solidjs/router";
 import { Offcanvas } from "bootstrap";
 import { type Component, createSignal } from "solid-js";
@@ -8,7 +9,7 @@ export const MainNav: Component = () => {
   return (
     <nav class="navbar navbar-expand-md bg-body-tertiary sticky-top">
       <div class="container">
-        <A class="navbar-brand" href="/">
+        <A class="navbar-brand" href={Paths.Home}>
           Asset Register
         </A>
 
@@ -41,7 +42,7 @@ export const MainNav: Component = () => {
               onClick={() => offcanvasInstance()?.hide()}
             >
               <li class="nav-item">
-                <A class="nav-link" activeClass="active" href="/" end>
+                <A class="nav-link" activeClass="active" href={Paths.Home} end>
                   Home
                 </A>
               </li>
@@ -50,7 +51,7 @@ export const MainNav: Component = () => {
                 <A
                   class="nav-link"
                   activeClass="active"
-                  href="/asset/create"
+                  href={Paths.CreateAsset}
                   end
                 >
                   Create Asset

--- a/workspaces/frontend/web/src/enums/Paths.ts
+++ b/workspaces/frontend/web/src/enums/Paths.ts
@@ -1,0 +1,10 @@
+/**
+ * All paths used in the app. These are typically named after the matching
+ * component for consistency.
+ */
+export const enum Paths {
+  Home = "/",
+  CreateAsset = "/asset/create",
+  ViewAsset = "/asset/:id",
+  EditAsset = "/asset/:id/edit",
+}

--- a/workspaces/frontend/web/src/pages/ViewAsset/ViewAsset.tsx
+++ b/workspaces/frontend/web/src/pages/ViewAsset/ViewAsset.tsx
@@ -1,8 +1,10 @@
 import { defaultDateTimeFormatter } from "../../common/intl.js";
+import { generatePath } from "../../common/route.js";
 import { formatSum } from "../../common/utils.js";
 import { Carousel } from "../../components/Carousel/Carousel.jsx";
 import { DropdownCaret } from "../../components/Dropdown/DropdownCaret.jsx";
 import type { AssetResource } from "../../data/index.js";
+import { Paths } from "../../enums/Paths.js";
 import { client } from "../../gql-client/client.js";
 import {
   DeleteAssetDocument,
@@ -99,7 +101,7 @@ export const ViewAsset: Component<{ data: AssetResource }> = (props) => {
                       <li>
                         <a
                           class="dropdown-item"
-                          href={`/asset/${asset.id}/edit`}
+                          href={generatePath(Paths.EditAsset, { id: asset.id })}
                         >
                           Edit
                         </a>

--- a/workspaces/frontend/web/src/routes.ts
+++ b/workspaces/frontend/web/src/routes.ts
@@ -4,35 +4,33 @@ import {
   loadAsset,
   loadAssetList,
 } from "./data/index.js";
+import { Paths } from "./enums/Paths.js";
 import { Home } from "./pages/Home.jsx";
 import type { RouteDefinition } from "@solidjs/router";
 import { lazy } from "solid-js";
 
-// TODO: maybe create a paths enum that can be used here and to generate paths
-// TODO: figure out if solid router provides a path generate helper function or write your own
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const routes: RouteDefinition<string | string[], any>[] = [
   {
-    path: "/",
+    path: Paths.Home,
     component: Home,
     preload: loadAssetList,
   } satisfies RouteDefinition<string, AssetListResource>,
   {
-    path: "/asset/create",
+    path: Paths.CreateAsset,
     component: lazy(async () => ({
       default: (await import("./pages/CreateAsset.jsx")).CreateAsset,
     })),
   },
   {
-    path: "/asset/:id",
+    path: Paths.ViewAsset,
     component: lazy(async () => ({
       default: (await import("./pages/ViewAsset/ViewAsset.jsx")).ViewAsset,
     })),
     preload: loadAsset,
   } satisfies RouteDefinition<string, AssetResource>,
   {
-    path: "/asset/:id/edit",
+    path: Paths.EditAsset,
     component: lazy(async () => ({
       default: (await import("./pages/EditAsset.jsx")).EditAsset,
     })),


### PR DESCRIPTION
Closes #54 

- Moved all paths to an enum
- Created a `generatePath` helper function that substitutes the placeholder segments in the given path. This is taken from the React Router `generatePath` helper function.